### PR TITLE
mkl-service cannot be installed by pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ lockfile==0.12.2
 Mako==1.1.3
 MarkupSafe==1.1.1
 matplotlib==3.2.1
-mkl-service==2.3.0
 multiprocess==0.70.11.1
 networkx==2.4
 numpy==1.17.0


### PR DESCRIPTION
Hi! Thanks for the great code you open-sourced!
I found that mkl-service can only be installed through conda, since you use `pip install -r requirements`, it should be removed.
Don't think mkl is needed in your project, right?

